### PR TITLE
prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/roycclu/react-native-fixed-header-scroll-view/issues"
   },
-  "homepage": "https://github.com/roycclu/react-native-fixed-header-scroll-view"
+  "homepage": "https://github.com/roycclu/react-native-fixed-header-scroll-view",
+  "dependencies": {
+    "prop-types": "^15.6.1"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,7 @@
 
 import React, { Component } from 'react';
 import { Dimensions, View, ViewPropTypes, ScrollView } from 'react-native';
-
-const { bool, func, number, string } = React.PropTypes;
+import { bool, func, number, string } from 'prop-types'
 
 const window = Dimensions.get('window');
 


### PR DESCRIPTION
React.PropTypes is deprecated. https://reactjs.org/docs/typechecking-with-proptypes.html